### PR TITLE
Add docker multistage build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         echo "New release detected, building and pushing Docker..."
         
         cat <<EOF > Dockerfile
-        FROM alpine:latest
+        FROM alpine:latest AS build
 
         RUN apk update && apk add --no-cache \
             git \
@@ -57,6 +57,9 @@ jobs:
         WORKDIR /opt/byedpi
         RUN make
         
+        FROM alpine:latest
+
+        COPY --from=build /opt /opt
         EXPOSE 1080
 
         ENTRYPOINT ["/opt/byedpi/ciadpi"]


### PR DESCRIPTION
1) Bad idea to keep compiler and dev packages in image
2) Multistage image is smaller